### PR TITLE
Implements metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ with following configuration (`hasMany`) :
   - "after"  : cursor-based navigation
 ```
 
+I case of relationships and if `StudioNet\GraphQL\Support\Type\Meta` type is
+registered, you'll be granted to use field like `_posts_meta { count }` in order
+to retrieve global count.
+
 This transformer also converts [mutated fields from model](https://laravel.com/docs/5.4/eloquent-mutators).
 Let's show you the convertion mapping (based on supported model cast) :
 
@@ -213,6 +217,17 @@ Generate singular query based on `EloquentObjectType`.
 - Return    : "Illuminate\Database\Eloquent\Model"
 - Arguments :
   - "id" : id-based navigation
+```
+
+#### `StudioNet\GraphQL\Generator\Query\MetaEloquentGenerator`
+
+Generate meta query based on `EloquentObjectType`.
+
+```
+- Type      : "EloquentObjectType"
+- Return    : [
+   - "count" : count of objects
+]
 ```
 
 #### `StudioNet\GraphQL\Generator\Query\NodesEloquentGenerator`
@@ -451,6 +466,44 @@ query {
 		posts {
 			title
 			content
+		}
+	}
+}
+```
+
+#### Using metadata
+
+```php
+# config/graphql.php
+
+return [
+	'type' => [
+		\StudioNet\GraphQL\Support\Type\Meta::class,
+		\App\User::class,
+		\App\Post::class
+	]
+];
+```
+
+```graphql
+query {
+	_users_meta {
+		count
+	}
+
+	users (take: 2) {
+		id
+		first_name
+		last_name
+
+		posts (take: 5) {
+			id
+			title
+			content
+		}
+
+		_posts_meta {
+			count
 		}
 	}
 }

--- a/resources/config.php
+++ b/resources/config.php
@@ -18,8 +18,14 @@ return [
 	],
 
 	// Type configuration. You can append any data : a transformer will handle
-	// them (if exists)
-	'type' => [],
+	// them (if exists). Order matter
+	'type' => [
+		// Mandatory in order to make working meta data
+		\StudioNet\GraphQL\Support\Type\Meta::class
+
+		// Custom types
+		// \App\User::class
+	],
 
 	// Scalar field definitions
 	'scalar' => [
@@ -57,6 +63,7 @@ return [
 	// all will be called
 	'generator' => [
 		'query'    => [
+			\StudioNet\GraphQL\Generator\Query\MetaEloquentGenerator::class,
 			\StudioNet\GraphQL\Generator\Query\NodeEloquentGenerator::class,
 			\StudioNet\GraphQL\Generator\Query\NodesEloquentGenerator::class
 		],

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -21,4 +21,11 @@ abstract class Generator implements GeneratorInterface {
 	public function __construct(Application $app) {
 		$this->app = $app;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function dependsOn() {
+		return [];
+	}
 }

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -28,4 +28,12 @@ interface GeneratorInterface {
 	 * @return string
 	 */
 	public function getKey($instance);
+
+	/**
+	 * Assert a specific type is registered before executing. If not, the
+	 * generator will not be triggered
+	 *
+	 * @return array
+	 */
+	public function dependsOn();
 }

--- a/src/Generator/Query/MetaEloquentGenerator.php
+++ b/src/Generator/Query/MetaEloquentGenerator.php
@@ -1,0 +1,70 @@
+<?php
+namespace StudioNet\GraphQL\Generator\Query;
+
+use GraphQL\Type\Definition\ResolveInfo;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use Illuminate\Database\Eloquent\Model;
+use StudioNet\GraphQL\Generator\Generator;
+use StudioNet\GraphQL\Type\EloquentObjectType;
+
+/**
+ * Generate meta query for given EloquentObjectType
+ *
+ * @see Generator
+ */
+class MetaEloquentGenerator extends Generator {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function supports($instance) {
+		return ($instance instanceof EloquentObjectType);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getKey($instance) {
+		return sprintf('_%s_meta', strtolower(str_plural($instance->name)));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function dependsOn() {
+		return ['meta'];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function generate($instance) {
+		return [
+			'type'    => $this->app['graphql']->type('meta'),
+			'resolve' => $this->getResolver($instance->getModel())
+		];
+	}
+
+	/**
+	 * Return meta resolver
+	 *
+	 * @param  Model $model
+	 * @return callable
+	 * @SuppressWarnings(PHPMD.UnusedLocalVariable)
+	 */
+	public function getResolver(Model $model) {
+		return function($root, array $args, $context, ResolveInfo $info) use ($model) {
+			// Clone collection in order to not erase existin collection
+			$collection = $model->newQuery();
+			$fields     = $info->getFieldSelection(3);
+			$data       = [];
+
+			foreach (array_keys($fields) as $key) {
+				switch ($key) {
+				case 'count' : $data['count'] = $collection->count(); break;
+				}
+			}
+
+			return $data;
+		};
+	}
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -341,7 +341,21 @@ class GraphQL {
 			throw new Exception\GeneratorException('Unable to find given category');
 		}
 
-		$this->generators[$category][] = $this->app->make($generator);
+		$generator    = $this->app->make($generator);
+		$dependencies = $generator->dependsOn();
+
+		// Assert generator has all is types dependencies
+		if (!empty($dependencies)) {
+			foreach ($dependencies as $dependency) {
+				$dependency = strtolower($dependency);
+
+				if (!array_key_exists($dependency, $this->types)) {
+					return;
+				}
+			}
+		}
+
+		$this->generators[$category][] = $generator;
 	}
 
 	/**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,9 +27,9 @@ class ServiceProvider extends BaseServiceProvider {
 		// Call external methods to load defined schemas and others things
 		$this->registerScalars();
 		$this->registerTransformers();
-		$this->registerGenerators();
 		$this->registerSchemas();
 		$this->registerTypes();
+		$this->registerGenerators();
 	}
 
 	/**

--- a/src/Support/Type/Meta.php
+++ b/src/Support/Type/Meta.php
@@ -1,0 +1,35 @@
+<?php
+namespace StudioNet\GraphQL\Support\Type;
+
+use StudioNet\GraphQL\Support\Type;
+use GraphQL\Type\Definition\Type as GraphQLType;
+
+/**
+ * Meta
+ *
+ * @see Type
+ */
+class Meta extends Type {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getName() {
+		return 'Meta';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getDescription() {
+		return 'Base-type metadata';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getFields() {
+		return [
+			'count' => ['type' => GraphQLType::nonNull(GraphQLType::int())],
+		];
+	}
+}

--- a/src/Transformer/TypeTransformer.php
+++ b/src/Transformer/TypeTransformer.php
@@ -39,8 +39,8 @@ class TypeTransformer extends Transformer {
 		// Merge all attributes within attributes var
 		$attributes = array_merge($attributes, [
 			'fields'      => $fields,
-			'name'        => $this->getName(),
-			'description' => $this->getDescription()
+			'name'        => $instance->getName(),
+			'description' => $instance->getDescription()
 		]);
 
 		if (!empty($interfaces)) {
@@ -64,7 +64,7 @@ class TypeTransformer extends Transformer {
 			return $field['resolve'];
 		}
 
-		$method = studly_case(sprintf('resolve-%s-%field', $name));
+		$method = studly_case(sprintf('resolve-%s-field', $name));
 
 		if (method_exists($type, $method)) {
 			return function() use ($type, $method) { return [$type, $method]; };


### PR DESCRIPTION
Metadatas are used in order to give more powerful data to user like counting available rows without taking care from `take` or `skip` arguments.

At now, it only implements `count` field. Meta are automatically generated from `EloquentObjectType` like : 

```graphql
query {
   _users_meta {
      count
   } 

   users (take: 2) {
      _posts_meta {
         count
      { 

      id
      name
      posts (take: 10) {
         id
         title
         content
      }
   }
}
```