### PR TITLE
Allow specifying camelCase fields in EloquentDefinitions

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -118,7 +118,7 @@ class GraphQL {
         $fieldResolver = function ($source, $args, $context, $info) {
             $result = Executor::defaultFieldResolver($source, $args, $context, $info);
 
-            if ($result === null && property_exists($source, snake_case($info->fieldName))) {
+            if ($result === null && isset($source->{snake_case($info->fieldName)})) {
                 $result = data_get($source, snake_case($info->fieldName));
             }
 

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -118,10 +118,8 @@ class GraphQL {
 		$fieldResolver = function ($source, $args, $context, $info) {
 			$result = Executor::defaultFieldResolver($source, $args, $context, $info);
 
-			$snakeCase = snake_case($info->fieldName);
-
-			if ($result === null && isset($source->{$snakeCase})) {
-				$result = $source->{$snakeCase};
+			if (is_null($result)) {
+				$result = data_get($source, snake_case($info->fieldName));
 			}
 
 			return $result;

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -110,12 +110,12 @@ class GraphQL {
 	 * @return array
 	 */
 	public function execute($query, $variables = [], $opts = []) {
-		$root       = array_get($opts, 'root', null);
-		$context    = array_get($opts, 'context', null);
-		$schemaName = array_get($opts, 'schema', null);
-		$operation  = array_get($opts, 'operationName', null);
-		$schema     = $this->getSchema($schemaName);
-        $fieldResolver   = function ($source, $args, $context, $info) {
+		$root          = array_get($opts, 'root', null);
+		$context       = array_get($opts, 'context', null);
+		$schemaName    = array_get($opts, 'schema', null);
+		$operation     = array_get($opts, 'operationName', null);
+		$schema        = $this->getSchema($schemaName);
+        $fieldResolver = function ($source, $args, $context, $info) {
             $result = Executor::defaultFieldResolver($source, $args, $context, $info);
 
             if ($result === null && property_exists($source, snake_case($info->fieldName))) {

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -115,17 +115,19 @@ class GraphQL {
 		$schemaName    = array_get($opts, 'schema', null);
 		$operation     = array_get($opts, 'operationName', null);
 		$schema        = $this->getSchema($schemaName);
-        $fieldResolver = function ($source, $args, $context, $info) {
-            $result = Executor::defaultFieldResolver($source, $args, $context, $info);
+		$fieldResolver = function ($source, $args, $context, $info) {
+			$result = Executor::defaultFieldResolver($source, $args, $context, $info);
 
-            if ($result === null && isset($source->{snake_case($info->fieldName)})) {
-                $result = data_get($source, snake_case($info->fieldName));
-            }
+			$snakeCase = snake_case($info->fieldName);
 
-            return $result;
-        };
+			if ($result === null && isset($source->{$snakeCase})) {
+				$result = $source->{$snakeCase};
+			}
 
-        return GraphQLBase::executeQuery($schema, $query, $root, $context, $variables, $operation, $fieldResolver)->toArray(true);
+			return $result;
+		};
+
+		return GraphQLBase::executeQuery($schema, $query, $root, $context, $variables, $operation, $fieldResolver)->toArray(true);
 	}
 
 	/**

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -125,7 +125,7 @@ class GraphQL {
             return $result;
         };
 
-        return GraphQLBase::executeQuery($schema, $query, $root, $context, $variables, $operation, $$fieldResolver)->toArray(true);
+        return GraphQLBase::executeQuery($schema, $query, $root, $context, $variables, $operation, $fieldResolver)->toArray(true);
 	}
 
 	/**

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -118,8 +118,8 @@ class GraphQL {
         $fieldResolver   = function ($source, $args, $context, $info) {
             $result = Executor::defaultFieldResolver($source, $args, $context, $info);
 
-            if ($result === null && $source instanceof Model && $snakified = $source->getAttribute(snake_case($info->fieldName))) {
-                $result = $snakified;
+            if ($result === null && property_exists($source, snake_case($info->fieldName))) {
+                $result = data_get($source, snake_case($info->fieldName));
             }
 
             return $result;

--- a/tests/Definition/CamelCaseUserDefinition.php
+++ b/tests/Definition/CamelCaseUserDefinition.php
@@ -1,0 +1,71 @@
+<?php
+namespace StudioNet\GraphQL\Tests\Definition;
+
+use StudioNet\GraphQL\Definition\Type;
+use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
+use StudioNet\GraphQL\Tests\Entity\User;
+
+/**
+ * Specify user GraphQL definition
+ *
+ * @see EloquentDefinition
+ */
+class CamelCaseUserDefinition extends EloquentDefinition {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	public function getName() {
+		return 'User';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	public function getDescription() {
+		return 'Represents a User';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return string
+	 */
+	public function getSource() {
+		return User::class;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getFetchable() {
+		return [
+			'id'          => Type::id(),
+			'name'        => Type::string(),
+			'lastLogin'  => Type::datetime(),
+			'isAdmin'    => Type::bool(),
+			'permissions' => Type::json(),
+			'posts'       => \GraphQL::listOf('post')
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getMutable() {
+		return [
+			'id'          => Type::id(),
+			'name'        => Type::string(),
+			'is_admin'    => Type::bool(),
+			'permissions' => Type::json(),
+			'password'    => Type::string()
+		];
+	}
+}

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -190,4 +190,32 @@ class GraphQLTest extends TestCase {
 			]);
 		});
 	}
+
+    public function testCamelCaseQuery()
+	{
+        factory(Entity\User::class)->create();
+
+        $graphql = app(GraphQL::class);
+        $graphql->registerSchema('default', [
+            'query' => [
+                \StudioNet\GraphQL\Tests\GraphQL\Query\Viewer::class
+            ]
+        ]);
+        $graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
+        $graphql->registerDefinition(Definition\PostDefinition::class);
+
+        $this->specify('test querying a single row with camel case fields', function() {
+            $query = 'query { user(id: 1) { name, isAdmin }}';
+            $user  = Entity\User::find(1);
+
+            $this->assertGraphQLEquals($query, [
+                'data' => [
+                    'user' => [
+                        'name' => $user->name,
+                        'isAdmin' => $user->is_admin,
+                    ]
+                ]
+            ]);
+        });
+	}
 }

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -191,31 +191,30 @@ class GraphQLTest extends TestCase {
 		});
 	}
 
-    public function testCamelCaseQuery()
-	{
-        factory(Entity\User::class)->create();
+    public function testCamelCaseQuery() {
+		factory(Entity\User::class)->create();
 
-        $graphql = app(GraphQL::class);
-        $graphql->registerSchema('default', [
-            'query' => [
-                \StudioNet\GraphQL\Tests\GraphQL\Query\Viewer::class
-            ]
-        ]);
-        $graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
-        $graphql->registerDefinition(Definition\PostDefinition::class);
+		$graphql = app(GraphQL::class);
+		$graphql->registerSchema('default', [
+			'query' => [
+				\StudioNet\GraphQL\Tests\GraphQL\Query\Viewer::class
+			]
+		]);
+		$graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
+		$graphql->registerDefinition(Definition\PostDefinition::class);
 
-        $this->specify('test querying a single row with camel case fields', function() {
-            $query = 'query { user(id: 1) { name, isAdmin }}';
-            $user  = Entity\User::find(1);
+		$this->specify('test querying a single row with camel case fields', function() {
+			$query = 'query { user(id: 1) { name, isAdmin }}';
+			$user  = Entity\User::find(1);
 
-            $this->assertGraphQLEquals($query, [
-                'data' => [
-                    'user' => [
-                        'name' => $user->name,
-                        'isAdmin' => $user->is_admin,
-                    ]
-                ]
-            ]);
-        });
+			$this->assertGraphQLEquals($query, [
+				'data' => [
+					'user' => [
+						'name' => $user->name,
+						'isAdmin' => $user->is_admin,
+					]
+				]
+			]);
+		});
 	}
 }


### PR DESCRIPTION
GraphQL style is to camelCase fields, however Eloquent properties are snake_case.

This PR will look for a camelCase field on an EloquentDefinition by converting it to snake_case before defaulting to null.