### PR TITLE
modifies Grammer::getKey to use strtolower instead converting to lowe…

### DIFF
--- a/src/Grammar/Grammar.php
+++ b/src/Grammar/Grammar.php
@@ -108,6 +108,6 @@ abstract class Grammar {
 	* @return string
 	*/
 	public function getKey($key) {
-		return sprintf('LOWER(%s)', $key);
+		return strtolower($key);
 	}
 }


### PR DESCRIPTION
modifies Grammer::getKey to use strtolower instead converting to lower case at the database level, as it was throwing a database error: ie ``Column not found: 1054 Unknown column 'LOWER(id)'``