### PR TITLE
Adds a search transformer

### DIFF
--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -180,7 +180,7 @@ class GraphQL {
 
 		return new ObjectType([
 			'name' => 'Query',
-			'fields' => $this->applyTransformers(['list', 'view'], $data)
+			'fields' => $this->applyTransformers(['list', 'view', 'search'], $data)
 		]);
 	}
 

--- a/src/Support/Definition/EloquentDefinition.php
+++ b/src/Support/Definition/EloquentDefinition.php
@@ -21,6 +21,7 @@ abstract class EloquentDefinition extends Definition {
 		'store' => \StudioNet\GraphQL\Support\Transformer\Eloquent\StoreTransformer::class,
 		'batch' => \StudioNet\GraphQL\Support\Transformer\Eloquent\BatchTransformer::class,
 		'restore' => \StudioNet\GraphQL\Support\Transformer\Eloquent\RestoreTransformer::class,
+        'search' => \StudioNet\GraphQL\Support\Transformer\Eloquent\SearchTransformer::class,
 	];
 
 	/**
@@ -35,7 +36,8 @@ abstract class EloquentDefinition extends Definition {
 			'drop' => true,
 			'store' => true,
 			'batch' => true,
-			'restore' => in_array(SoftDeletes::class, class_uses($this->getSource()))
+			'restore' => in_array(SoftDeletes::class, class_uses($this->getSource())),
+            'search' => in_array('Laravel\\Scout\\Searchable', class_uses($this->getSource()))
 		];
 	}
 

--- a/src/Support/Transformer/Eloquent/SearchTransformer.php
+++ b/src/Support/Transformer/Eloquent/SearchTransformer.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace StudioNet\GraphQL\Support\Transformer\Eloquent;
+
+use StudioNet\GraphQL\Definition\Type;
+use StudioNet\GraphQL\Support\Definition\Definition;
+use StudioNet\GraphQL\Support\Transformer\Transformer;
+
+class SearchTransformer extends Transformer
+{
+    /**
+     * Return query name
+     *
+     * @param  Definition $definition
+     * @return string
+     */
+    public function getName(Definition $definition) {
+        return sprintf('search%s', ucfirst(strtolower(str_plural($definition->getName()))));
+    }
+
+    /**
+     * Resolve type
+     *
+     * @param  Definition $definition
+     *
+     * @return \GraphQL\Type\Definition\ObjectType|\GraphQL\Type\Definition\ListOfType
+     */
+    public function resolveType(Definition $definition)
+    {
+        return Type::listOf($definition->resolveType());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param  Definition $definition
+     * @return array
+     */
+    public function getArguments(Definition $definition)
+    {
+        return [
+            'query' => [
+                'type' => Type::nonNull(Type::string()),
+                'description' => 'Search terms'
+            ],
+            'index' => [
+                'type' => Type::string(),
+                'description' => 'The index to search'
+            ]
+        ];
+    }
+
+    /**
+     * Return fetchable node resolver
+     *
+     * @param  array $opts
+     * @return \Illuminate\Database\Eloquent\Collection
+     */
+    public function getResolver(array $opts)
+    {
+        $builder = call_user_func(get_class($opts['source']).'::search', $opts['args']['query']);
+
+        foreach ($opts['args'] as $key => $value) {
+            switch ($key) {
+                case 'index':
+                    $builder->within($value);
+                    break;
+
+            }
+        }
+
+        return $builder->get();
+    }
+}

--- a/tests/Support/Definition/DefinitionTest.php
+++ b/tests/Support/Definition/DefinitionTest.php
@@ -86,6 +86,7 @@ class DefinitionTest extends TestCase {
 			$this->assertArrayHasKey('drop', $definition->transformers);
 			$this->assertArrayHasKey('store', $definition->transformers);
 			$this->assertArrayHasKey('batch', $definition->transformers);
+            $this->assertArrayHasKey('search', $definition->transformers);
 		});
 
 		$this->specify('ensure getTransformers method return all $transformers elements', function () use ($definition) {


### PR DESCRIPTION
I wanted to add the ability to search with Laravel Scout, but there's not really a way to add custom transformers at the moment at run time, and custom queries were very very verbose.

This PR adds a transformer to search with Laravel Scout, which is automatically activated when the Eloquent model uses `Laravel\Scout\Searchable`, similar to `SoftDeletes`.