### PR TITLE
Fixing n+1 relations problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /.php_cs.cache
 *.orig
+/.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,52 +1,30 @@
 language      : php
-php           : [5.6, 7.0, 7.1]
+php           : [7.1, 7.2]
 cache         : { directories : [$COMPOSER_CACHE_DIR, $HOME/.composer/cache, vendor] }
 install       : composer update --no-interaction --prefer-dist
 notifications :
-    email : false
+  email : false
 
 stages :
-    - test
-    - lint
-
-env :
-    - TESTBENCH_VERSION=3.2.* LARAVEL_VERSION=5.2.*
-    - TESTBENCH_VERSION=3.3.* LARAVEL_VERSION=5.3.*
-    - TESTBENCH_VERSION=3.4.* LARAVEL_VERSION=5.4.*
-    - TESTBENCH_VERSION=3.5.* LARAVEL_VERSION=5.5.*
-    - TESTBENCH_VERSION=3.6.*@dev LARAVEL_VERSION=5.6.*
-
-matrix :
-    exclude :
-        - php : 5.6
-          env : TESTBENCH_VERSION=3.5.* LARAVEL_VERSION=5.5.*
-        - php : 5.6
-          env : TESTBENCH_VERSION=3.6.*@dev LARAVEL_VERSION=5.6.*
-        - php : 7.0
-          env : TESTBENCH_VERSION=3.6.*@dev LARAVEL_VERSION=5.6.*
+- test
+- lint
 
 script :
-    - vendor/bin/phpunit
+- vendor/bin/phpunit
 
 before_install :
-    - composer global require hirak/prestissimo --update-no-dev
-    - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update --prefer-dist
-    - composer require "orchestra/testbench-browser-kit:${TESTBENCH_VERSION}" --no-update --prefer-dist
+- composer global require hirak/prestissimo --update-no-dev
 
 jobs :
-    include :
-        - stage : lint
-          php   : 7.1
-          env   : TESTBENCH_VERSION=3.6.*@dev LARAVEL_VERSION=5.6.*
-          before_install :
-            - composer global require hirak/prestissimo --update-no-dev
-            - composer require "laravel/framework:${LARAVEL_VERSION}" --no-update --prefer-dist
-            - composer require "orchestra/testbench-browser-kit:${TESTBENCH_VERSION}" --no-update --prefer-dist
-            - composer require phpmd/phpmd --no-update --prefer-dist
-            - composer require phpstan/phpstan --no-update --prefer-dist
-            - composer require friendsofphp/php-cs-fixer --no-update --prefer-dist
-          script :
-              - vendor/bin/phpmd src text phpmd.xml
-              - vendor/bin/phpmd tests text phpmd.xml
-              - vendor/bin/phpstan analyse --autoload-file=_ide_helper.php --level 1 src
-              - vendor/bin/php-cs-fixer fix -v --dry-run --stop-on-violation --using-cache=no
+  include :
+  - stage : lint
+    php   : 7.2
+    env   : TESTBENCH_VERSION=3.6.* LARAVEL_VERSION=5.6.*
+    before_install :
+    - composer global require hirak/prestissimo --update-no-dev
+    - composer require phpmd/phpmd --no-update --prefer-dist
+    - composer require phpstan/phpstan --no-update --prefer-dist
+    script :
+    - vendor/bin/phpmd src text phpmd.xml
+    - vendor/bin/phpmd tests text phpmd.xml
+    - vendor/bin/phpstan analyse --autoload-file=_ide_helper.php --level 1 src

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ use StudioNet\GraphQL\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
 use StudioNet\GraphQL\Filter\EqualsOrContainsFilter;
 use App\User;
+use Auth;
 
 /**
  * Specify user GraphQL definition
@@ -185,8 +186,17 @@ namespace App\GraphQL\Query;
 use StudioNet\GraphQL\Support\Definition\Query;
 use Illuminate\Support\Facades\Auth;
 use App\User;
+use Auth;
 
 class Viewer extends Query {
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function authorize(array $args) {
+		// check, that user is not a guest
+		return !Auth::guest();
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
@@ -253,6 +263,14 @@ use StudioNet\GraphQL\Definition\Type;
 use App\User;
 
 class Profile extends Mutation {
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function authorize(array $args) {
+		// check, that user is not a guest
+		return !Auth::guest();
+	}
+
 	/**
 	 * {@inheritDoc}
 	 *

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ php artisan vendor:publish --provider="StudioNet\GraphQL\ServiceProvider"
 - [Require authorization](#require-authorization)
 - [Self documentation](#self-documentation)
 - [Examples](#examples)
+- [N+1 Problem](#n+1-problem)
 
 ### Definition
 
@@ -603,6 +604,14 @@ post-save (which can be useful for eloquent relational models) :
 		];
 	}
 ```
+
+### N+1 Problem
+
+The common question is, if graphql library solves n+1 problem. This occures, when graphql resolves relation. Often entities are fetched without relations, and when graphql query needs to fetch relation, for each fetched entity relation would be fetched from SQL separately. So instead of executing 2 SQL queries, you will get N+1 queries, where N is the count of results of root entity. In that example you would query only one relation. If you query more relations, then it becomes N^2+1 problem.
+
+To solve it, Eloquent has already options to eager load relations. Transformers in this library use eager loading, depends on what you query.
+
+Currently this smart detection works perfect only on View and List Transformers. Other transformers will be reworked soon.
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ php artisan vendor:publish --provider="StudioNet\GraphQL\ServiceProvider"
 - [Definition](#definition)
 - [Query](#query)
 - [Mutation](#mutation)
+- [Require authorization](#require-authorization)
 - [Self documentation](#self-documentation)
 - [Examples](#examples)
 
@@ -328,6 +329,14 @@ return [
 	]
 ];
 ```
+
+### Require authorization
+
+Currently you have a possibility to protect your own queries and mutations. You have to implement `authorize()` method in your query/mutation, that return a boolean, that indicates, if requested query/mutation has to be executed. If method return `false`, an `UNAUTHORIZED` GraphQL-Error will be thrown.
+
+Usage examples are in query and mutation above.
+
+Protection of definition transformers are currently not implemented, but may be will in the future. By now you have to define your query/mutation yourself, and protect it then with logic in `authorize()`.
 
 ### Self documentation
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ namespace App\GraphQL\Query;
 
 use StudioNet\GraphQL\Support\Definition\Query;
 use Illuminate\Support\Facades\Auth;
+use App\User;
 
 class Viewer extends Query {
 	/**
@@ -192,13 +193,20 @@ class Viewer extends Query {
 	public function getRelatedType() {
 		return \GraphQL::type('user');
 	}
+	
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getSource() {
+		return User::class;
+	}
 
 	/**
 	 * Return logged user
 	 *
-	 * @return \App\User|null
+	 * @return User|null
 	 */
-	public function getResolver() {
+	public function getResolver($opts) {
 		return Auth::user();
 	}
 }
@@ -221,6 +229,15 @@ return [
 	]
 ];
 ```
+
+`getResolver()` receives an array-argument with followed item:
+
+- `root` 1st argument given by webonyx library - `GraphQL\Executor\Executor::resolveOrError()`
+- `args` 2nd argument given by webonyx library
+- `context` 3rd argument given by webonyx library
+- `info` 4th argument given by webonyx library
+- `fields` array of fields, that were fetched from query. Limited by depth in `StudioNet\GraphQL\GraphQL::FIELD_SELECTION_DEPTH`
+- `with` array of relations, that could/should be eager loaded. **NOTICE:** Finding this relations happens ONLY, if `getSource()` is defined - this method should return a class name of a associated root-type in query. If `getSource()` is not defined, then `with` will be always empty.
 
 ### Mutation
 

--- a/database/factories/Comment.php
+++ b/database/factories/Comment.php
@@ -1,0 +1,9 @@
+<?php
+use Faker\Generator;
+use StudioNet\GraphQL\Tests\Entity;
+
+$factory->define(Entity\Comment::class, function (Generator $faker) {
+	return [
+		'body' => $faker->text(100)
+	];
+});

--- a/database/factories/Country.php
+++ b/database/factories/Country.php
@@ -1,0 +1,9 @@
+<?php
+use Faker\Generator;
+use StudioNet\GraphQL\Tests\Entity;
+
+$factory->define(Entity\Country::class, function (Generator $faker) {
+	return [
+		'name' => $faker->country
+	];
+});

--- a/database/factories/Label.php
+++ b/database/factories/Label.php
@@ -1,0 +1,9 @@
+<?php
+use Faker\Generator;
+use StudioNet\GraphQL\Tests\Entity;
+
+$factory->define(Entity\Label::class, function (Generator $faker) {
+	return [
+		'name' => $faker->word
+	];
+});

--- a/database/factories/Phone.php
+++ b/database/factories/Phone.php
@@ -1,0 +1,10 @@
+<?php
+use Faker\Generator;
+use StudioNet\GraphQL\Tests\Entity;
+
+$factory->define(Entity\Phone::class, function (Generator $faker) {
+	return [
+		'label' => $faker->word,
+		'number' => $faker->phoneNumber
+	];
+});

--- a/database/migrations/2018_08_07_021200_create_phones_table.php
+++ b/database/migrations/2018_08_07_021200_create_phones_table.php
@@ -1,0 +1,33 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * CreatePhonesTable
+ *
+ * @see Migration
+ */
+class CreatePhonesTable extends Migration {
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up() {
+		Schema::create('phones', function ($table) {
+			$table->increments('id');
+
+			$table->string('label');
+			$table->string('number');
+			$table->unsignedInteger('user_id');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down() {
+		Schema::drop('phones');
+	}
+}

--- a/database/migrations/2018_08_07_022900_create_countries_table_and_extend_users_table.php
+++ b/database/migrations/2018_08_07_022900_create_countries_table_and_extend_users_table.php
@@ -8,15 +8,13 @@ use Illuminate\Database\Schema\Blueprint;
  *
  * @see Migration
  */
-class CreateCountriesTableAndExtendUsersTable extends Migration
-{
+class CreateCountriesTableAndExtendUsersTable extends Migration {
 	/**
 	 * Run the migrations.
 	 *
 	 * @return void
 	 */
-	public function up()
-	{
+	public function up() {
 		Schema::create('countries', function (Blueprint $table) {
 			$table->increments('id');
 			$table->string('name');
@@ -32,8 +30,7 @@ class CreateCountriesTableAndExtendUsersTable extends Migration
 	 *
 	 * @return void
 	 */
-	public function down()
-	{
+	public function down() {
 		Schema::table('users', function (Blueprint $table) {
 			$table->dropColumn('country_id');
 		});

--- a/database/migrations/2018_08_07_022900_create_countries_table_and_extend_users_table.php
+++ b/database/migrations/2018_08_07_022900_create_countries_table_and_extend_users_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * CreateCountriesTable
+ *
+ * @see Migration
+ */
+class CreateCountriesTableAndExtendUsersTable extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('countries', function (Blueprint $table) {
+			$table->increments('id');
+			$table->string('name');
+		});
+
+		Schema::table('users', function (Blueprint $table) {
+			$table->unsignedInteger('country_id')->nullable();
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('users', function (Blueprint $table) {
+			$table->dropColumn('country_id');
+		});
+		Schema::drop('phones');
+	}
+}

--- a/database/migrations/2018_08_08_144100_create_comments_table.php
+++ b/database/migrations/2018_08_08_144100_create_comments_table.php
@@ -22,6 +22,7 @@ class CreateCommentsTable extends Migration
 			$table->text('body');
 			$table->unsignedInteger('commentable_id');
 			$table->string('commentable_type');
+			$table->timestamps();
 		});
 	}
 

--- a/database/migrations/2018_08_08_144100_create_comments_table.php
+++ b/database/migrations/2018_08_08_144100_create_comments_table.php
@@ -8,15 +8,13 @@ use Illuminate\Database\Schema\Blueprint;
  *
  * @see Migration
  */
-class CreateCommentsTable extends Migration
-{
+class CreateCommentsTable extends Migration {
 	/**
 	 * Run the migrations.
 	 *
 	 * @return void
 	 */
-	public function up()
-	{
+	public function up() {
 		Schema::create('comments', function (Blueprint $table) {
 			$table->increments('id');
 			$table->text('body');
@@ -31,8 +29,7 @@ class CreateCommentsTable extends Migration
 	 *
 	 * @return void
 	 */
-	public function down()
-	{
+	public function down() {
 		Schema::drop('comments');
 	}
 }

--- a/database/migrations/2018_08_08_144100_create_comments_table.php
+++ b/database/migrations/2018_08_08_144100_create_comments_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * CreateCommentsTable
+ *
+ * @see Migration
+ */
+class CreateCommentsTable extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('comments', function (Blueprint $table) {
+			$table->increments('id');
+			$table->text('body');
+			$table->unsignedInteger('commentable_id');
+			$table->string('commentable_type');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('comments');
+	}
+}

--- a/database/migrations/2018_08_08_153400_create_labels_and_labelables_tables.php
+++ b/database/migrations/2018_08_08_153400_create_labels_and_labelables_tables.php
@@ -8,15 +8,13 @@ use Illuminate\Database\Schema\Blueprint;
  *
  * @see Migration
  */
-class CreateLabelsAndLabelablesTables extends Migration
-{
+class CreateLabelsAndLabelablesTables extends Migration {
 	/**
 	 * Run the migrations.
 	 *
 	 * @return void
 	 */
-	public function up()
-	{
+	public function up() {
 		Schema::create('labels', function (Blueprint $table) {
 			$table->increments('id');
 			$table->text('name');
@@ -33,8 +31,7 @@ class CreateLabelsAndLabelablesTables extends Migration
 	 *
 	 * @return void
 	 */
-	public function down()
-	{
+	public function down() {
 		Schema::drop('labelables');
 		Schema::drop('labels');
 	}

--- a/database/migrations/2018_08_08_153400_create_labels_and_labelables_tables.php
+++ b/database/migrations/2018_08_08_153400_create_labels_and_labelables_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+/**
+ * CreateLabelsAndLabelablesTables
+ *
+ * @see Migration
+ */
+class CreateLabelsAndLabelablesTables extends Migration
+{
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::create('labels', function (Blueprint $table) {
+			$table->increments('id');
+			$table->text('name');
+		});
+		Schema::create('labelables', function (Blueprint $table) {
+			$table->unsignedInteger('label_id');
+			$table->unsignedInteger('labelable_id');
+			$table->string('labelable_type');
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::drop('labelables');
+		Schema::drop('labels');
+	}
+}

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -362,5 +362,4 @@ class GraphQL {
 
 		return $relations;
 	}
-
 }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -7,6 +7,7 @@ use GraphQL\Schema;
 use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as Type;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Application;
 use StudioNet\GraphQL\Cache\CachePool;
 use StudioNet\GraphQL\Support\Definition\Definition;
@@ -329,4 +330,37 @@ class GraphQL {
 	private function make($cls) {
 		return (is_string($cls)) ? $this->app->make($cls) : $cls;
 	}
+
+	/**
+	 * Return relationship based on fields that are queried
+	 *
+	 * @param  Model $model
+	 * @param  array $fields
+	 * @param  string $parentRelation
+	 *
+	 * @return array
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+	 */
+	public static function guessWithRelations(Model $model, array $fields, string $parentRelation = null) {
+		$relations = [];
+		// Parse each field in order to retrieve relationship elements on root
+		// of array (as relationship are based upon multiple resolvers, we just
+		// have to handle the root fields here)
+		foreach ($fields as $key => $field) {
+			if (is_array($field) && method_exists($model, $key)) {
+				// verify, that given method returns relation
+				$relation = call_user_func([$model, $key]);
+				if ($relation instanceof Relation) {
+					$relationNameToStore = $parentRelation ? "{$parentRelation}.{$key}" : $key;
+					$relations[] = $relationNameToStore;
+
+					// also guess relations for found relation
+					$relations = array_merge($relations, self::guessWithRelations($relation->getModel(), $field, $relationNameToStore));
+				}
+			}
+		}
+
+		return $relations;
+	}
+
 }

--- a/src/GraphQL.php
+++ b/src/GraphQL.php
@@ -25,6 +25,9 @@ class GraphQL {
 	/** @var CachePool $cache */
 	private $cache;
 
+	/** @var int Depth-level, how deep fields will be fetched for relations guessing */
+	const FIELD_SELECTION_DEPTH = 3;
+
 	/**
 	 * __construct
 	 *

--- a/src/Support/Definition/Definition.php
+++ b/src/Support/Definition/Definition.php
@@ -81,7 +81,7 @@ abstract class Definition implements DefinitionInterface {
 	/**
 	 * Returns availabled pipes
 	 *
-	 * @return void
+	 * @return array
 	 */
 	public function getPipes(): array {
 		return [];

--- a/src/Support/Definition/Field.php
+++ b/src/Support/Definition/Field.php
@@ -88,7 +88,7 @@ abstract class Field implements FieldInterface {
 
 				$opts = [
 					'root'    => $root,
-					'args'    => array_filter($args),
+					'args'    => $args,
 					'context' => $context,
 					'info'    => $info,
 					'fields'  => $fields,

--- a/src/Support/Definition/Field.php
+++ b/src/Support/Definition/Field.php
@@ -24,6 +24,7 @@ abstract class Field implements FieldInterface {
 	 *
 	 * @param  array $args
 	 * @return boolean
+	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
 	protected function authorize(array $args) {
 		return true;
@@ -33,7 +34,6 @@ abstract class Field implements FieldInterface {
 	 * __construct
 	 *
 	 * @param  Application $app
-	 * @param  CachePool $cache
 	 * @return void
 	 */
 	public function __construct(Application $app) {

--- a/src/Support/Definition/Field.php
+++ b/src/Support/Definition/Field.php
@@ -87,12 +87,12 @@ abstract class Field implements FieldInterface {
 				$fields = $info->getFieldSelection(GraphQL::FIELD_SELECTION_DEPTH);
 
 				$opts = [
-					'root'    => $root,
-					'args'    => $args,
+					'root' => $root,
+					'args' => $args,
 					'context' => $context,
-					'info'    => $info,
-					'fields'  => $fields,
-					'with'    => []
+					'info' => $info,
+					'fields' => $fields,
+					'with' => []
 				];
 
 				// if getSource() returns some model, then guess relation for eager loading

--- a/src/Support/Pipe/Eloquent/FilterPipe.php
+++ b/src/Support/Pipe/Eloquent/FilterPipe.php
@@ -29,9 +29,9 @@ class FilterPipe implements Argumentable {
 			$grammar = null;
 
 			switch ($driver) {
-				case 'pgsql'  : $grammar  = new Grammar\PostgreSQLGrammar ; break;
-				case 'mysql'  : $grammar  = new Grammar\MySQLGrammar      ; break;
-				case 'sqlite' : $grammar = new Grammar\SqliteGrammar      ; break;
+				case 'pgsql': $grammar = new Grammar\PostgreSQLGrammar ; break;
+				case 'mysql': $grammar = new Grammar\MySQLGrammar      ; break;
+				case 'sqlite': $grammar = new Grammar\SqliteGrammar      ; break;
 			}
 
 			// Assert that grammar exists

--- a/src/Support/Pipe/Pipeline.php
+++ b/src/Support/Pipe/Pipeline.php
@@ -18,7 +18,7 @@ class Pipeline extends PipelineBase {
 	 * @override
 	 * @return \Closure
 	 */
-    protected function carry() {
+	protected function carry() {
 		return function ($stack, $pipe) {
 			return function ($passable) use ($stack, $pipe) {
 				if (is_callable($pipe)) {
@@ -26,9 +26,7 @@ class Pipeline extends PipelineBase {
 					// otherwise we'll resolve the pipes out of the container and call it with
 					// the appropriate method and arguments, returning the results back out.
 					return $pipe($passable, $stack, ...$this->parameters);
-				}
-
-				elseif (!is_object($pipe)) {
+				} elseif (!is_object($pipe)) {
 					list($name, $parameters) = $this->parsePipeString($pipe);
 
 					// If the pipe is a string we will parse the string and resolve the class out
@@ -36,9 +34,7 @@ class Pipeline extends PipelineBase {
 					// execute the pipe function giving in the parameters that are required.
 					$pipe = $this->getContainer()->make($name);
 					$parameters = array_merge([$passable, $stack], array_merge($this->parameters, $parameters));
-				}
-
-				else {
+				} else {
 					// If the pipe is already an object we'll just make a callable and pass it to
 					// the pipe as-is. There is no need to do any extra parsing and formatting
 					// since the object we're given was already a fully instantiated object.
@@ -48,7 +44,7 @@ class Pipeline extends PipelineBase {
 				return method_exists($pipe, $this->method) ? $pipe->{$this->method}(...$parameters) : $pipe(...$parameters);
 			};
 		};
-    }
+	}
 
 	/**
 	 * with

--- a/src/Support/Transformer/Eloquent/ListTransformer.php
+++ b/src/Support/Transformer/Eloquent/ListTransformer.php
@@ -1,6 +1,7 @@
 <?php
 namespace StudioNet\GraphQL\Support\Transformer\Eloquent;
 
+use StudioNet\GraphQL\Support\Transformer\Paginable;
 use StudioNet\GraphQL\Support\Transformer\Transformer;
 use StudioNet\GraphQL\Support\Definition\Definition;
 use StudioNet\GraphQL\Grammar;
@@ -16,7 +17,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  * @see Transformer
  */
-class ListTransformer extends Transformer {
+class ListTransformer extends Transformer implements Paginable {
 	/**
 	 * Return query name
 	 *

--- a/src/Support/Transformer/Eloquent/ListTransformer.php
+++ b/src/Support/Transformer/Eloquent/ListTransformer.php
@@ -169,7 +169,7 @@ class ListTransformer extends Transformer {
 			if (!empty($take)) {
 				$res['page'] = ceil($skip / $take);
 				$res['numPages'] = ceil($totalCount / $take);
-				$res['hasNextPage'] = $res['page'] < $res['numPages'];
+				$res['hasNextPage'] = $res['page'] < $res['numPages'] - 1;
 				$res['hasPreviousPage'] = $res['page'] > 0;
 			}
 			return $res;

--- a/src/Support/Transformer/EloquentTransformer.php
+++ b/src/Support/Transformer/EloquentTransformer.php
@@ -1,9 +1,9 @@
 <?php
 namespace StudioNet\GraphQL\Support\Transformer;
 
-use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use StudioNet\GraphQL\Support\Pipe\Pipeline;
+use StudioNet\GraphQL\Support\Transformer\Eloquent\StoreTransformer;
 
 /**
  * EloquentTransformer
@@ -18,8 +18,14 @@ abstract class EloquentTransformer extends Transformer {
 	 * @return \Illuminate\Database\Eloquent\Collection|\Illuminate\Database\Eloquent\Model|array
 	 */
 	protected function getResolver(array $opts) {
+		$query = $opts['source']->newQuery();
+		// this is a small workaround, that should be omitted and reworked with store transformer!
+		// add with only, if we don't use store transformer
+		if ((!$opts['transformer'] instanceof StoreTransformer)) {
+			$query->with($opts['with']);
+		}
 		return (new Pipeline($this->app))
-			->send($opts['source']->newQuery())
+			->send($query)
 			->with($opts)
 			->through($this->getPipes($opts['definition']))
 			->then(function (Builder $builder) use ($opts) {

--- a/src/Support/Transformer/Paginable.php
+++ b/src/Support/Transformer/Paginable.php
@@ -1,0 +1,8 @@
+<?php
+
+
+namespace StudioNet\GraphQL\Support\Transformer;
+
+interface Paginable {
+
+}

--- a/src/Support/Transformer/Paginable.php
+++ b/src/Support/Transformer/Paginable.php
@@ -4,5 +4,4 @@
 namespace StudioNet\GraphQL\Support\Transformer;
 
 interface Paginable {
-
 }

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -75,8 +75,11 @@ abstract class Transformer extends Cachable {
 		return function ($root, array $args, $context, ResolveInfo $info) use ($definition, $app) {
 			$reflect = new \ReflectionClass($this);
 
-			$isListTransformer = $reflect->getShortName() === "ListTransformer";
-			$fieldsDepth = $isListTransformer ? 4 : 3; // may be increase depth?
+			// check, if Paginable interface was implemented by given Transformer
+			// Paginable interface has an extra wrapper for data-fields
+			$isPaginable = $this instanceof Paginable;
+
+			$fieldsDepth = $isPaginable ? 4 : 3; // may be increase depth?
 			$fields = $info->getFieldSelection($fieldsDepth);
 
 			$definition->assertAcl(
@@ -89,7 +92,7 @@ abstract class Transformer extends Cachable {
 				]
 			);
 
-			$fieldsForGuessingRelations = $isListTransformer ? $fields['items'] : $fields;
+			$fieldsForGuessingRelations = $isPaginable ? $fields['items'] : $fields;
 
 			$opts = [
 				'root' => $root,

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -134,9 +134,10 @@ abstract class Transformer extends Cachable {
 				if ($relation instanceof Relation) {
 					$relationNameToStore = $parentRelation ? "{$parentRelation}.{$key}" : $key;
 					$relations[] = $relationNameToStore;
+
+					// also guess relations for found relation
+					$relations = array_merge($relations, $this->guessWithRelations($relation->getModel(), $field, $relationNameToStore));
 				}
-				// also guess relations for found relation
-				$relations = array_merge($relations, $this->guessWithRelations($relation->getModel(), $field, $relationNameToStore));
 			}
 		}
 

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -78,7 +78,7 @@ abstract class Transformer extends Cachable {
 			// Paginable interface has an extra wrapper for data-fields
 			$isPaginable = $this instanceof Paginable;
 
-			$fieldsDepth = $isPaginable ? 4 : 3; // may be increase depth?
+			$fieldsDepth = $isPaginable ? GraphQL::FIELD_SELECTION_DEPTH + 1 : GraphQL::FIELD_SELECTION_DEPTH;
 			$fields = $info->getFieldSelection($fieldsDepth);
 
 			$definition->assertAcl(

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -1,12 +1,13 @@
 <?php
 namespace StudioNet\GraphQL\Support\Transformer;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Application;
 use StudioNet\GraphQL\Support\Definition\Definition;
 use GraphQL\Type\Definition\ResolveInfo;
 use StudioNet\GraphQL\Cache\Cachable;
 use StudioNet\GraphQL\Cache\CachePool;
-use GraphQL\Type\Definition\InputObjectType;
 
 /**
  * Define transformer base class
@@ -72,8 +73,12 @@ abstract class Transformer extends Cachable {
 		$app = $this->app;
 
 		return function ($root, array $args, $context, ResolveInfo $info) use ($definition, $app) {
-			$fields = $info->getFieldSelection(3);
 			$reflect = new \ReflectionClass($this);
+
+			$isListTransformer = $reflect->getShortName() === "ListTransformer";
+			$fieldsDepth = $isListTransformer ? 4 : 3; // may be increase depth?
+			$fields = $info->getFieldSelection($fieldsDepth);
+
 			$definition->assertAcl(
 				str_replace("transformer", "", strtolower($reflect->getShortName())),
 				[
@@ -84,13 +89,15 @@ abstract class Transformer extends Cachable {
 				]
 			);
 
+			$fieldsForGuessingRelations = $isListTransformer ? $fields['items'] : $fields;
+
 			$opts = [
 				'root' => $root,
 				'args' => array_filter($args),
 				'fields' => $fields,
 				'context' => $context,
 				'info' => $info,
-				'with' => $this->guessWithRelations($definition, $fields),
+				'with' => $this->guessWithRelations($this->app->make($definition->getSource()), $fieldsForGuessingRelations),
 				'source' => $app->make($definition->getSource()),
 				'rules' => $definition->getRules(),
 				'filterables' => $definition->getFilterable(),
@@ -102,24 +109,29 @@ abstract class Transformer extends Cachable {
 	}
 
 	/**
-	 * Return relationship based on entity definition construction
+	 * Return relationship based on fields that are queried
 	 *
-	 * @param  Definition $definition
+	 * @param  Model $model
 	 * @param  array $fields
+	 * @param  string $parentRelation
+	 *
 	 * @return array
 	 * @SuppressWarnings(PHPMD.UnusedFormalParameter)
 	 */
-	public function guessWithRelations(Definition $definition, array $fields) {
+	public function guessWithRelations(Model $model, array $fields, string $parentRelation = null) {
 		$relations = [];
-		$source = $this->app->make($definition->getSource());
-
 		// Parse each field in order to retrieve relationship elements on root
 		// of array (as relationship are based upon multiple resolvers, we just
 		// have to handle the root fields here)
 		foreach ($fields as $key => $field) {
-			// TODO Improve this checker
-			if (is_array($field) and method_exists($source, $key)) {
-				array_push($relations, $key);
+			if (is_array($field) && method_exists($model, $key)) {
+				// get relation name and store it
+				/** @var BelongsToMany $relation */
+				$relation = call_user_func([$model, $key]);
+				$relationNameToStore = $parentRelation ? "{$parentRelation}.{$relation->getRelationName()}" : $relation->getRelationName();
+				$relations[] = $relationNameToStore;
+				// also guess relations for found relation
+				$relations = array_merge($relations, $this->guessWithRelations($relation->getModel(), $field, $relationNameToStore));
 			}
 		}
 

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -71,9 +71,7 @@ abstract class Transformer extends Cachable {
 	 * @return callable
 	 */
 	public function getResolverCallable(Definition $definition) {
-		$app = $this->app;
-
-		return function ($root, array $args, $context, ResolveInfo $info) use ($definition, $app) {
+		return function ($root, array $args, $context, ResolveInfo $info) use ($definition) {
 			$reflect = new \ReflectionClass($this);
 
 			// check, if Paginable interface was implemented by given Transformer
@@ -102,7 +100,7 @@ abstract class Transformer extends Cachable {
 				'context' => $context,
 				'info' => $info,
 				'with' => $this->guessWithRelations($this->app->make($definition->getSource()), $fieldsForGuessingRelations),
-				'source' => $app->make($definition->getSource()),
+				'source' => $this->app->make($definition->getSource()),
 				'rules' => $definition->getRules(),
 				'filterables' => $definition->getFilterable(),
 				'definition' => $definition,

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -1,8 +1,8 @@
 <?php
+
 namespace StudioNet\GraphQL\Support\Transformer;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Application;
 use StudioNet\GraphQL\Support\Definition\Definition;
 use GraphQL\Type\Definition\ResolveInfo;
@@ -126,9 +126,13 @@ abstract class Transformer extends Cachable {
 		foreach ($fields as $key => $field) {
 			if (is_array($field) && method_exists($model, $key)) {
 				// get relation name and store it
-				/** @var BelongsToMany $relation */
 				$relation = call_user_func([$model, $key]);
-				$relationNameToStore = $parentRelation ? "{$parentRelation}.{$relation->getRelationName()}" : $relation->getRelationName();
+				if (method_exists($relation, 'getRelationName')) {
+					$relationName = $relation->getRelationName();
+				} else {
+					$relationName = explode('.', $relation->getQualifiedForeignKeyName())[0];
+				}
+				$relationNameToStore = $parentRelation ? "{$parentRelation}.{$relationName}" : $relationName;
 				$relations[] = $relationNameToStore;
 				// also guess relations for found relation
 				$relations = array_merge($relations, $this->guessWithRelations($relation->getModel(), $field, $relationNameToStore));

--- a/src/Support/Transformer/Transformer.php
+++ b/src/Support/Transformer/Transformer.php
@@ -71,8 +71,6 @@ abstract class Transformer extends Cachable {
 	 */
 	public function getResolverCallable(Definition $definition) {
 		return function ($root, array $args, $context, ResolveInfo $info) use ($definition) {
-			$reflect = new \ReflectionClass($this);
-
 			// check, if Paginable interface was implemented by given Transformer
 			// Paginable interface has an extra wrapper for data-fields
 			$isPaginable = $this instanceof Paginable;

--- a/tests/Definition/CommentDefinition.php
+++ b/tests/Definition/CommentDefinition.php
@@ -74,5 +74,4 @@ class CommentDefinition extends EloquentDefinition {
 			'id' => new EqualsOrContainsFilter()
 		];
 	}
-
 }

--- a/tests/Definition/CommentDefinition.php
+++ b/tests/Definition/CommentDefinition.php
@@ -3,21 +3,22 @@ namespace StudioNet\GraphQL\Tests\Definition;
 
 use StudioNet\GraphQL\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
-use StudioNet\GraphQL\Tests\Entity\User;
+use StudioNet\GraphQL\Tests\Entity\Country;
+use StudioNet\GraphQL\Filter\EqualsOrContainsFilter;
 
 /**
  * Specify user GraphQL definition
  *
  * @see EloquentDefinition
  */
-class CamelCaseUserDefinition extends EloquentDefinition {
+class CommentDefinition extends EloquentDefinition {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @return string
 	 */
 	public function getName() {
-		return 'User';
+		return 'Comment';
 	}
 
 	/**
@@ -26,7 +27,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getDescription() {
-		return 'Represents a User';
+		return 'Represents a Comment';
 	}
 
 	/**
@@ -35,7 +36,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getSource() {
-		return User::class;
+		return Country::class;
 	}
 
 	/**
@@ -46,15 +47,8 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	public function getFetchable() {
 		return [
 			'id' => Type::id(),
-			'name' => Type::string(),
-			'lastLogin' => Type::datetime(),
-			'isAdmin' => Type::bool(),
-			'permissions' => Type::json(),
-			'posts' => \GraphQL::listOf('post'),
-			'phone' => \GraphQL::type('phone'),
-			'country' => \GraphQL::type('country'),
-			'comments' => \GraphQL::listOf('comment'),
-			'labels' => \GraphQL::listOf('label')
+			'body' => Type::string(),
+//			'commentable' => \GraphQL::listOf('post')
 		];
 	}
 
@@ -66,10 +60,19 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	public function getMutable() {
 		return [
 			'id' => Type::id(),
-			'name' => Type::string(),
-			'is_admin' => Type::bool(),
-			'permissions' => Type::json(),
-			'password' => Type::string()
+			'body' => Type::string(),
 		];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getFilterable() {
+		return [
+			'id' => new EqualsOrContainsFilter()
+		];
+	}
+
 }

--- a/tests/Definition/CountryDefinition.php
+++ b/tests/Definition/CountryDefinition.php
@@ -3,21 +3,22 @@ namespace StudioNet\GraphQL\Tests\Definition;
 
 use StudioNet\GraphQL\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
-use StudioNet\GraphQL\Tests\Entity\User;
+use StudioNet\GraphQL\Tests\Entity\Country;
+use StudioNet\GraphQL\Filter\EqualsOrContainsFilter;
 
 /**
  * Specify user GraphQL definition
  *
  * @see EloquentDefinition
  */
-class CamelCaseUserDefinition extends EloquentDefinition {
+class CountryDefinition extends EloquentDefinition {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @return string
 	 */
 	public function getName() {
-		return 'User';
+		return 'Country';
 	}
 
 	/**
@@ -26,7 +27,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getDescription() {
-		return 'Represents a User';
+		return 'Represents a Country';
 	}
 
 	/**
@@ -35,7 +36,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getSource() {
-		return User::class;
+		return Country::class;
 	}
 
 	/**
@@ -47,14 +48,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 		return [
 			'id' => Type::id(),
 			'name' => Type::string(),
-			'lastLogin' => Type::datetime(),
-			'isAdmin' => Type::bool(),
-			'permissions' => Type::json(),
-			'posts' => \GraphQL::listOf('post'),
-			'phone' => \GraphQL::type('phone'),
-			'country' => \GraphQL::type('country'),
-			'comments' => \GraphQL::listOf('comment'),
-			'labels' => \GraphQL::listOf('label')
+			'posts' => \GraphQL::listOf('post')
 		];
 	}
 
@@ -67,9 +61,18 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 		return [
 			'id' => Type::id(),
 			'name' => Type::string(),
-			'is_admin' => Type::bool(),
-			'permissions' => Type::json(),
-			'password' => Type::string()
 		];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getFilterable() {
+		return [
+			'id' => new EqualsOrContainsFilter()
+		];
+	}
+
 }

--- a/tests/Definition/CountryDefinition.php
+++ b/tests/Definition/CountryDefinition.php
@@ -74,5 +74,4 @@ class CountryDefinition extends EloquentDefinition {
 			'id' => new EqualsOrContainsFilter()
 		];
 	}
-
 }

--- a/tests/Definition/LabelDefinition.php
+++ b/tests/Definition/LabelDefinition.php
@@ -75,5 +75,4 @@ class LabelDefinition extends EloquentDefinition {
 			'id' => new EqualsOrContainsFilter()
 		];
 	}
-
 }

--- a/tests/Definition/LabelDefinition.php
+++ b/tests/Definition/LabelDefinition.php
@@ -3,21 +3,22 @@ namespace StudioNet\GraphQL\Tests\Definition;
 
 use StudioNet\GraphQL\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
-use StudioNet\GraphQL\Tests\Entity\User;
+use StudioNet\GraphQL\Filter\EqualsOrContainsFilter;
+use StudioNet\GraphQL\Tests\Entity\Label;
 
 /**
  * Specify user GraphQL definition
  *
  * @see EloquentDefinition
  */
-class CamelCaseUserDefinition extends EloquentDefinition {
+class LabelDefinition extends EloquentDefinition {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @return string
 	 */
 	public function getName() {
-		return 'User';
+		return 'Label';
 	}
 
 	/**
@@ -26,7 +27,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getDescription() {
-		return 'Represents a User';
+		return 'Represents a Label';
 	}
 
 	/**
@@ -35,7 +36,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getSource() {
-		return User::class;
+		return Label::class;
 	}
 
 	/**
@@ -47,14 +48,8 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 		return [
 			'id' => Type::id(),
 			'name' => Type::string(),
-			'lastLogin' => Type::datetime(),
-			'isAdmin' => Type::bool(),
-			'permissions' => Type::json(),
 			'posts' => \GraphQL::listOf('post'),
-			'phone' => \GraphQL::type('phone'),
-			'country' => \GraphQL::type('country'),
-			'comments' => \GraphQL::listOf('comment'),
-			'labels' => \GraphQL::listOf('label')
+			'users' => \GraphQL::listOf('user'),
 		];
 	}
 
@@ -67,9 +62,18 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 		return [
 			'id' => Type::id(),
 			'name' => Type::string(),
-			'is_admin' => Type::bool(),
-			'permissions' => Type::json(),
-			'password' => Type::string()
 		];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getFilterable() {
+		return [
+			'id' => new EqualsOrContainsFilter()
+		];
+	}
+
 }

--- a/tests/Definition/PhoneDefinition.php
+++ b/tests/Definition/PhoneDefinition.php
@@ -3,21 +3,22 @@ namespace StudioNet\GraphQL\Tests\Definition;
 
 use StudioNet\GraphQL\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\EloquentDefinition;
-use StudioNet\GraphQL\Tests\Entity\User;
+use StudioNet\GraphQL\Tests\Entity\Phone;
+use StudioNet\GraphQL\Filter\EqualsOrContainsFilter;
 
 /**
  * Specify user GraphQL definition
  *
  * @see EloquentDefinition
  */
-class CamelCaseUserDefinition extends EloquentDefinition {
+class PhoneDefinition extends EloquentDefinition {
 	/**
 	 * {@inheritDoc}
 	 *
 	 * @return string
 	 */
 	public function getName() {
-		return 'User';
+		return 'Phone';
 	}
 
 	/**
@@ -26,7 +27,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getDescription() {
-		return 'Represents a User';
+		return 'Represents a Phone';
 	}
 
 	/**
@@ -35,7 +36,7 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	 * @return string
 	 */
 	public function getSource() {
-		return User::class;
+		return Phone::class;
 	}
 
 	/**
@@ -46,15 +47,9 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	public function getFetchable() {
 		return [
 			'id' => Type::id(),
-			'name' => Type::string(),
-			'lastLogin' => Type::datetime(),
-			'isAdmin' => Type::bool(),
-			'permissions' => Type::json(),
-			'posts' => \GraphQL::listOf('post'),
-			'phone' => \GraphQL::type('phone'),
-			'country' => \GraphQL::type('country'),
-			'comments' => \GraphQL::listOf('comment'),
-			'labels' => \GraphQL::listOf('label')
+			'label' => Type::string(),
+			'number' => Type::string(),
+			'user' => \GraphQL::type('user')
 		];
 	}
 
@@ -66,10 +61,20 @@ class CamelCaseUserDefinition extends EloquentDefinition {
 	public function getMutable() {
 		return [
 			'id' => Type::id(),
-			'name' => Type::string(),
-			'is_admin' => Type::bool(),
-			'permissions' => Type::json(),
-			'password' => Type::string()
+			'label' => Type::string(),
+			'number' => Type::string(),
 		];
 	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array
+	 */
+	public function getFilterable() {
+		return [
+			'id' => new EqualsOrContainsFilter()
+		];
+	}
+
 }

--- a/tests/Definition/PhoneDefinition.php
+++ b/tests/Definition/PhoneDefinition.php
@@ -76,5 +76,4 @@ class PhoneDefinition extends EloquentDefinition {
 			'id' => new EqualsOrContainsFilter()
 		];
 	}
-
 }

--- a/tests/Definition/PostDefinition.php
+++ b/tests/Definition/PostDefinition.php
@@ -49,6 +49,8 @@ class PostDefinition extends EloquentDefinition {
 			'title' => Type::string(),
 			'content' => Type::string(),
 			'tags' => \GraphQL::listOf('tag'),
+			'comments' => \GraphQL::listOf('comment'),
+			'labels' => \GraphQL::listOf('label')
 		];
 	}
 

--- a/tests/Definition/PostDefinition.php
+++ b/tests/Definition/PostDefinition.php
@@ -48,6 +48,7 @@ class PostDefinition extends EloquentDefinition {
 			'id' => Type::id(),
 			'title' => Type::string(),
 			'content' => Type::string(),
+			'author' => \GraphQL::type('user'),
 			'tags' => \GraphQL::listOf('tag'),
 			'comments' => \GraphQL::listOf('comment'),
 			'labels' => \GraphQL::listOf('label')

--- a/tests/Definition/UserDefinition.php
+++ b/tests/Definition/UserDefinition.php
@@ -52,7 +52,11 @@ class UserDefinition extends EloquentDefinition {
 			'last_login' => Type::datetime(),
 			'is_admin' => Type::bool(),
 			'permissions' => Type::json(),
-			'posts' => \GraphQL::listOf('post')
+			'posts' => \GraphQL::listOf('post'),
+			'phone' => \GraphQL::type('phone'),
+			'country' => \GraphQL::type('country'),
+			'comments' => \GraphQL::listOf('comment'),
+			'labels' => \GraphQL::listOf('label')
 		];
 	}
 

--- a/tests/Entity/Comment.php
+++ b/tests/Entity/Comment.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\Entity;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class Comment extends Model
+{
+	/**
+	 * Get all of the owning commentable models.
+	 */
+	public function commentable()
+	{
+		return $this->morphTo();
+	}
+}

--- a/tests/Entity/Comment.php
+++ b/tests/Entity/Comment.php
@@ -5,13 +5,11 @@ namespace StudioNet\GraphQL\Tests\Entity;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-class Comment extends Model
-{
+class Comment extends Model {
 	/**
 	 * Get all of the owning commentable models.
 	 */
-	public function commentable()
-	{
+	public function commentable() {
 		return $this->morphTo();
 	}
 }

--- a/tests/Entity/Country.php
+++ b/tests/Entity/Country.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\Entity;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class Country extends Model
+{
+	/**
+	 * Get all of the posts for the country.
+	 *
+	 * @return HasManyThrough
+	 */
+	public function posts()
+	{
+		return $this->hasManyThrough(Post::class, User::class);
+	}
+}

--- a/tests/Entity/Country.php
+++ b/tests/Entity/Country.php
@@ -5,8 +5,7 @@ namespace StudioNet\GraphQL\Tests\Entity;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-class Country extends Model
-{
+class Country extends Model {
 	public $timestamps = false;
 
 	/**
@@ -14,8 +13,7 @@ class Country extends Model
 	 *
 	 * @return HasManyThrough
 	 */
-	public function posts()
-	{
+	public function posts() {
 		return $this->hasManyThrough(Post::class, User::class);
 	}
 }

--- a/tests/Entity/Country.php
+++ b/tests/Entity/Country.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Country extends Model
 {
+	public $timestamps = false;
+
 	/**
 	 * Get all of the posts for the country.
 	 *

--- a/tests/Entity/Label.php
+++ b/tests/Entity/Label.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
 class Label extends Model
 {
+	public $timestamps = false;
+
 	public function posts()
 	{
 		return $this->morphedByMany(Post::class, 'labelable');

--- a/tests/Entity/Label.php
+++ b/tests/Entity/Label.php
@@ -5,17 +5,14 @@ namespace StudioNet\GraphQL\Tests\Entity;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 
-class Label extends Model
-{
+class Label extends Model {
 	public $timestamps = false;
 
-	public function posts()
-	{
+	public function posts() {
 		return $this->morphedByMany(Post::class, 'labelable');
 	}
 
-	public function users()
-	{
+	public function users() {
 		return $this->morphedByMany(User::class, 'labelable');
 	}
 }

--- a/tests/Entity/Label.php
+++ b/tests/Entity/Label.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\Entity;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
+
+class Label extends Model
+{
+	public function posts()
+	{
+		return $this->morphedByMany(Post::class, 'labelable');
+	}
+
+	public function users()
+	{
+		return $this->morphedByMany(User::class, 'labelable');
+	}
+}

--- a/tests/Entity/Phone.php
+++ b/tests/Entity/Phone.php
@@ -7,6 +7,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Phone extends Model
 {
+	public $timestamps = false;
+
 	/**
 	 * Get the user that owns the phone.
 	 *

--- a/tests/Entity/Phone.php
+++ b/tests/Entity/Phone.php
@@ -5,8 +5,7 @@ namespace StudioNet\GraphQL\Tests\Entity;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class Phone extends Model
-{
+class Phone extends Model {
 	public $timestamps = false;
 
 	/**
@@ -14,8 +13,7 @@ class Phone extends Model
 	 *
 	 * @return BelongsTo
 	 */
-	public function user()
-	{
+	public function user() {
 		return $this->belongsTo(User::class);
 	}
 }

--- a/tests/Entity/Phone.php
+++ b/tests/Entity/Phone.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\Entity;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Phone extends Model
+{
+	/**
+	 * Get the user that owns the phone.
+	 *
+	 * @return BelongsTo
+	 */
+	public function user()
+	{
+		return $this->belongsTo(User::class);
+	}
+}

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -18,7 +18,7 @@ class Post extends Model {
 	 * @return \Illuminate\Database\Eloquent\Relations\Relation
 	 */
 	public function author() {
-		return $this->belongsTo(User::class);
+		return $this->belongsTo(User::class, 'user_id');
 	}
 
 	/**

--- a/tests/Entity/Post.php
+++ b/tests/Entity/Post.php
@@ -15,7 +15,7 @@ class Post extends Model {
 	/**
 	 * Return related posts
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\Relation
+	 * @return \Illuminate\Database\Eloquent\Relations\Relation
 	 */
 	public function author() {
 		return $this->belongsTo(User::class);
@@ -24,7 +24,7 @@ class Post extends Model {
 	/**
 	 * Return related tags
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\Relation
+	 * @return \Illuminate\Database\Eloquent\Relations\Relation
 	 */
 	public function tags() {
 		return $this->belongsToMany(
@@ -33,5 +33,13 @@ class Post extends Model {
 			'post_id',
 			'tag_id'
 		);
+	}
+
+	public function comments() {
+		return $this->morphMany(Comment::class, 'commentable');
+	}
+
+	public function labels() {
+		return $this->morphToMany(Label::class, 'labelable');
 	}
 }

--- a/tests/Entity/Tag.php
+++ b/tests/Entity/Tag.php
@@ -15,7 +15,7 @@ class Tag extends Model {
 	/**
 	 * Return related posts
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\Relation
+	 * @return \Illuminate\Database\Eloquent\Relations\Relation
 	 */
 	public function posts() {
 		return $this->belongsToMany(

--- a/tests/Entity/User.php
+++ b/tests/Entity/User.php
@@ -42,8 +42,7 @@ class User extends Model {
 	 *
 	 * @return HasOne
 	 */
-	public function phone()
-	{
+	public function phone() {
 		return $this->hasOne(Phone::class);
 	}
 

--- a/tests/Entity/User.php
+++ b/tests/Entity/User.php
@@ -2,6 +2,8 @@
 namespace StudioNet\GraphQL\Tests\Entity;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * User
@@ -29,9 +31,31 @@ class User extends Model {
 	/**
 	 * Return related posts
 	 *
-	 * @return Illuminate\Database\Eloquent\Relations\Relation
+	 * @return HasMany
 	 */
 	public function posts() {
 		return $this->hasMany(Post::class);
+	}
+
+	/**
+	 * Get the phone record associated with the user.
+	 *
+	 * @return HasOne
+	 */
+	public function phone()
+	{
+		return $this->hasOne(Phone::class);
+	}
+
+	public function country() {
+		return $this->belongsTo(Country::class);
+	}
+
+	public function comments() {
+		return $this->morphMany(Comment::class, 'commentable');
+	}
+
+	public function labels() {
+		return $this->morphToMany(Label::class, 'labelable');
 	}
 }

--- a/tests/GraphQL/Query/SimpleString.php
+++ b/tests/GraphQL/Query/SimpleString.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\GraphQL\Query;
+
+use StudioNet\GraphQL\Definition\Type;
+use StudioNet\GraphQL\Support\Definition\Query;
+
+class SimpleString extends Query {
+	public function getRelatedType() {
+		return Type::string();
+	}
+
+	public function getResolver() {
+		return 'You got this!';
+	}
+}

--- a/tests/GraphQL/Query/Unauthorized.php
+++ b/tests/GraphQL/Query/Unauthorized.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests\GraphQL\Query;
+
+use GraphQL\Type\Definition\Type;
+use StudioNet\GraphQL\Support\Definition\Query;
+
+class Unauthorized extends Query {
+	protected function authorize() {
+		return false;
+	}
+
+	public function getRelatedType() {
+		return Type::string();
+	}
+
+	public function getResolver() {
+		return 'You got this!';
+	}
+}

--- a/tests/GraphQL/Query/Unauthorized.php
+++ b/tests/GraphQL/Query/Unauthorized.php
@@ -6,7 +6,7 @@ use GraphQL\Type\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\Query;
 
 class Unauthorized extends Query {
-	protected function authorize() {
+	protected function authorize(array $args) {
 		return false;
 	}
 

--- a/tests/GraphQL/Query/Unauthorized.php
+++ b/tests/GraphQL/Query/Unauthorized.php
@@ -6,6 +6,9 @@ use GraphQL\Type\Definition\Type;
 use StudioNet\GraphQL\Support\Definition\Query;
 
 class Unauthorized extends Query {
+	/**
+	 * {@inheritdoc}
+	 */
 	protected function authorize(array $args) {
 		return false;
 	}

--- a/tests/GraphQL/Query/Viewer.php
+++ b/tests/GraphQL/Query/Viewer.php
@@ -28,12 +28,17 @@ class Viewer extends Query {
 		return \GraphQL::type('user');
 	}
 
+	public function getSource()
+	{
+		return User::class;
+	}
+
 	/**
 	 * Resolve query
 	 *
 	 * @return User
 	 */
-	public function getResolver() {
-		return User::first();
+	public function getResolver($opts) {
+		return User::with($opts['with'])->first();
 	}
 }

--- a/tests/GraphQL/Query/Viewer.php
+++ b/tests/GraphQL/Query/Viewer.php
@@ -28,6 +28,9 @@ class Viewer extends Query {
 		return \GraphQL::type('user');
 	}
 
+	/**
+	 * {@inheritdoc}
+	 */
 	public function getSource()
 	{
 		return User::class;

--- a/tests/GraphQL/Query/Viewer.php
+++ b/tests/GraphQL/Query/Viewer.php
@@ -31,8 +31,7 @@ class Viewer extends Query {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function getSource()
-	{
+	public function getSource() {
 		return User::class;
 	}
 

--- a/tests/GraphQLMutationTest.php
+++ b/tests/GraphQLMutationTest.php
@@ -1,10 +1,6 @@
 <?php
 namespace StudioNet\GraphQL\Tests;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type as GraphQLType;
-use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
 
 /**
@@ -21,12 +17,8 @@ class GraphQLMutationTest extends TestCase {
 	 */
 	public function testMutation() {
 		factory(Entity\User::class, 5)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests mutation on user', function () {
 			$query = 'mutation { user(id: 1, with: { name: "toto" }) { id, name } }';
@@ -102,12 +94,8 @@ class GraphQLMutationTest extends TestCase {
 	 */
 	public function testNestedMutation() {
 		factory(Entity\User::class, 5)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests nested mutation on user', function () {
 			$query = <<<'GQL'
@@ -181,12 +169,8 @@ GQL;
 	 */
 	public function testNestedEditMutation() {
 		factory(Entity\User::class, 5)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests nested mutation on user', function () {
 			$query = <<<'GQL'
@@ -256,12 +240,8 @@ GQL;
 	 */
 	public function testNestedEditNullMutation() {
 		factory(Entity\User::class, 5)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests nested mutation on user', function () {
 			$query = <<<'GQL'
@@ -355,11 +335,7 @@ GQL;
 		}
 		$tagsUpdate = implode(",", $tagUpdate);
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify(
 			'tests nested m:n mutation on post',
@@ -393,12 +369,8 @@ GQL;
 	 */
 	public function testMutationCustomInputField() {
 		factory(Entity\User::class, 1)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests custom input field on user', function () {
 			$query = 'mutation { user(id: 1, with: {'
@@ -428,12 +400,8 @@ GQL;
 	 */
 	public function testMutationCustomInputFieldException() {
 		factory(Entity\User::class, 1)->create();
-		
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->registerAllDefinitions();
 
 		$this->specify('tests custom input field on user, with error', function () {
 			$query = 'mutation { user(id: 1, with: {'

--- a/tests/GraphQLPaginationTest.php
+++ b/tests/GraphQLPaginationTest.php
@@ -1,0 +1,141 @@
+<?php
+namespace StudioNet\GraphQL\Tests;
+
+use GraphQL\Type\Definition\ListOfType;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type as GraphQLType;
+use StudioNet\GraphQL\GraphQL;
+use StudioNet\GraphQL\Tests\Entity;
+
+/**
+ * Pagination tests
+ */
+class GraphQLPaginationTest extends TestCase {
+
+	/**
+	 */
+	public function testOrderBy() {
+		foreach (['aa','bb','cc','dd'] as $name) {
+			factory(Entity\User::class)->create(['name' => $name]);
+		}
+
+		$graphql = app(GraphQL::class);
+		$graphql->registerSchema('default', []);
+		$graphql->registerDefinition(Definition\UserDefinition::class);
+		$graphql->registerDefinition(Definition\PostDefinition::class);
+		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$this->specify('test order_by', function () {
+			$query = <<<'EOGQL'
+query {
+	users(order_by: ["name_desc"]) {
+		items {
+				name
+		}
+	}
+}
+EOGQL;
+
+			$res = $this->executeGraphQL($query);
+
+			$this->assertSame(
+				['dd','cc','bb','aa'],
+				array_column($res['data']['users']['items'], 'name')
+			);
+		});
+	}
+
+	/**
+	 */
+	public function testOrderByWithPages() {
+		foreach (['aa','bb','cc','dd','ee','ff'] as $name) {
+			factory(Entity\User::class)->create(['name' => $name]);
+		}
+
+		$graphql = app(GraphQL::class);
+		$graphql->registerSchema('default', []);
+		$graphql->registerDefinition(Definition\UserDefinition::class);
+		$graphql->registerDefinition(Definition\PostDefinition::class);
+		$graphql->registerDefinition(Definition\TagDefinition::class);
+
+		$query = <<<'EOGQL'
+query ($skip: Int, $take: Int) {
+	users(order_by: ["name_desc"], take: $take, skip: $skip) {
+		pagination {
+			totalCount
+			page
+			numPages
+			hasNextPage
+			hasPreviousPage
+		}
+		items {
+			name
+		}
+	}
+}
+EOGQL;
+
+		$this->specify('test with pagesize 2', function () use ($query) {
+			$opts = ['variables' => ['take' => 2]];
+
+			// Page 0
+			$opts['variables']['skip'] = 0;
+			$res = $this->executeGraphQL($query, $opts);
+			$this->assertSame([
+					'totalCount' => 6,
+					'page' => 0,
+					'numPages' => 3,
+					'hasNextPage' => true,
+					'hasPreviousPage' => false,
+				], $res['data']['users']['pagination']);
+
+			// Page 1
+			$opts['variables']['skip'] = 2;
+			$res = $this->executeGraphQL($query, $opts);
+			$this->assertSame([
+					'totalCount' => 6,
+					'page' => 1,
+					'numPages' => 3,
+					'hasNextPage' => true,
+					'hasPreviousPage' => true,
+				], $res['data']['users']['pagination']);
+			
+			// Page 2
+			$opts['variables']['skip'] = 4;
+			$res = $this->executeGraphQL($query, $opts);
+			$this->assertSame([
+					'totalCount' => 6,
+					'page' => 2,
+					'numPages' => 3,
+					'hasNextPage' => false,
+					'hasPreviousPage' => true,
+				], $res['data']['users']['pagination']);
+		});
+
+		$this->specify('test with pagesize 4', function () use ($query) {
+			$opts = ['variables' => ['take' => 4]];
+
+			// Page 0
+			$opts['variables']['skip'] = 0;
+			$res = $this->executeGraphQL($query, $opts);
+			$this->assertSame([
+					'totalCount' => 6,
+					'page' => 0,
+					'numPages' => 2,
+					'hasNextPage' => true,
+					'hasPreviousPage' => false,
+				], $res['data']['users']['pagination']);
+
+			// Page 1
+			$opts['variables']['skip'] = 2;
+			$res = $this->executeGraphQL($query, $opts);
+			$this->assertSame([
+					'totalCount' => 6,
+					'page' => 1,
+					'numPages' => 2,
+					'hasNextPage' => false,
+					'hasPreviousPage' => true,
+				], $res['data']['users']['pagination']);
+		});
+	}
+}

--- a/tests/GraphQLPaginationTest.php
+++ b/tests/GraphQLPaginationTest.php
@@ -19,11 +19,7 @@ class GraphQLPaginationTest extends TestCase {
 			factory(Entity\User::class)->create(['name' => $name]);
 		}
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('test order_by', function () {
 			$query = <<<'EOGQL'
@@ -52,11 +48,7 @@ EOGQL;
 			factory(Entity\User::class)->create(['name' => $name]);
 		}
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$query = <<<'EOGQL'
 query ($skip: Int, $take: Int) {

--- a/tests/GraphQLPaginationTest.php
+++ b/tests/GraphQLPaginationTest.php
@@ -1,10 +1,6 @@
 <?php
 namespace StudioNet\GraphQL\Tests;
 
-use GraphQL\Type\Definition\ListOfType;
-use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type as GraphQLType;
-use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
 
 /**

--- a/tests/GraphQLRelationsTest.php
+++ b/tests/GraphQLRelationsTest.php
@@ -1,0 +1,408 @@
+<?php
+
+namespace StudioNet\GraphQL\Tests;
+
+use Illuminate\Support\Facades\DB;
+use StudioNet\GraphQL\Tests\Entity;
+
+/**
+ * Tests for relations resolving.
+ * The main point of this tests is to make sure, that eager loading works, also in deep queries.
+ * The correctness of returned GraphQL response is not tested.
+ *
+ * @see TestCase
+ */
+class GraphQLRelationsTest extends TestCase
+{
+	/**
+	 * Test 1-1 Relation
+	 *
+	 * @return void
+	 */
+	public function testOneToOneRelation()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->phone()->save(factory(Entity\Phone::class)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing 1-1 relation', function () {
+			// fetch data directly
+			Entity\User::with('phone')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { users { items {name phone { label number } }}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+	/**
+	 * Test 1-1 Relation inverse
+	 *
+	 * @return void
+	 */
+	public function testOneToOneRelationInverse()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->phone()->save(factory(Entity\Phone::class)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing 1-1 relation inverse', function () {
+			// fetch data directly
+			Entity\Phone::with('user')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { phones { items { label number user { name } }}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+
+	/**
+	 * Test 1-* Relation
+	 *
+	 * @return void
+	 */
+	public function testOneToManyRelation()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->posts()->saveMany(factory(Entity\Post::class, 5)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing 1-* relation', function () {
+			// fetch data directly
+			Entity\User::with('posts')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { users { items {name posts { title content } }}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+
+	/**
+	 * Test 1-* Relation inverse
+	 *
+	 * @return void
+	 */
+	public function testOneToManyRelationInverse()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->posts()->saveMany(factory(Entity\Post::class, 5)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing 1-* relation inverse', function () {
+			// fetch data directly
+			Entity\Post::with('author')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { posts { items {title content author { name } }}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+
+	/**
+	 * Test HasManyThrough Relation
+	 *
+	 * @return void
+	 */
+	public function testHasManyThroughRelation()
+	{
+		factory(Entity\Country::class, 2)->create()->each(function ($country) {
+			factory(Entity\User::class, 2)->create([
+				'country_id' => $country->id
+			])->each(function ($user) {
+				factory(Entity\Post::class, 5)->create([
+					'user_id' => $user->id
+				]);
+			});
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing HasManyThrough relation', function () {
+			// fetch data directly
+			Entity\Country::with('posts')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { countries { items { name posts { title content }}}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+	/**
+	 * Test Polymorphic 1-1 Relation
+	 *
+	 * @return void
+	 */
+	public function testPolymorphicOneToOneRelation()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->comments()->saveMany(factory(Entity\Comment::class, 5)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing polymorphic 1-1 relation', function () {
+			// fetch data directly
+			Entity\User::with('comments')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { users { items { name comments { body }}}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+	/**
+	 * Test Polymorphic *-* Relation
+	 *
+	 * @return void
+	 */
+	public function testPolymorphicManyToManyRelation()
+	{
+		factory(Entity\User::class, 5)->create()->each(function ($user) {
+			$user->labels()->saveMany(factory(Entity\Label::class, 5)->make());
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing polymorphic *-* relation', function () {
+			// fetch data directly
+			Entity\User::with('labels')->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { users { items { name labels { name }}}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+	/**
+	 * Test Polymorphic *-* Relation inverse
+	 *
+	 * @return void
+	 */
+	public function testPolymorphicManyToManyRelationInverse()
+	{
+		factory(Entity\User::class, 4)->create()->each(function ($user) {
+			$user->labels()->saveMany(factory(Entity\Label::class, 3)->make());
+			factory(Entity\Post::class, 2)->create([
+				'user_id' => $user->id
+			])->each(function ($post) {
+				$post->labels()->saveMany(factory(Entity\Label::class, 2)->make());
+			});
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing polymorphic *-* relation inverse', function () {
+			// fetch data directly
+			Entity\Label::with(['users', 'posts'])->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { labels { items { name users { name } posts { title } }}}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+
+	/**
+	 * Test deep relations
+	 *
+	 * @return void
+	 */
+	public function testDeepRelations()
+	{
+		factory(Entity\Country::class, 2)->create()->each(function ($country) {
+			factory(Entity\User::class, 2)->create([
+				'country_id' => $country->id
+			])->each(function ($user) {
+				$user->phone()->save(factory(Entity\Phone::class)->make());
+				factory(Entity\Post::class, 2)->create([
+					'user_id' => $user->id
+				])->each(function ($post) {
+					$post->labels()->saveMany(factory(Entity\Label::class, 2)->make());
+					$post->tags()->saveMany(factory(Entity\Tag::class, 2)->make());
+				});
+			});
+		});
+
+		$this->registerAllDefinitions();
+
+		// enable query log for comparing queries
+		DB::enableQueryLog();
+
+		$this->specify('Testing polymorphic *-* relation inverse', function () {
+			// fetch data directly
+			Entity\Country::with(['posts', 'posts.labels', 'posts.tags', 'posts.author', 'posts.author.phone'])->get();
+
+			// get query log and remove 'time' property from each query-element
+			$madeQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			DB::flushQueryLog();
+
+			// fetch data with graphql
+			$query = 'query { 
+				countries { 
+					items { 
+						name 
+						posts { 
+							title 
+							labels { 
+								name 
+							} 
+							tags { 
+								name 
+							} 
+							author { 
+								name 
+								phone {
+									label 
+									number 
+								}
+							} 
+						}
+					}
+				}
+			}';
+			$this->executeGraphQL($query);
+
+			// get query log produced duricng fetching over graphql and remove 'time' property from each query-element
+			$gqlQueries = $this->removeTimeElementFromQueryLog(DB::getQueryLog());
+
+			// queries should be the same
+			$this->assertSame($madeQueries, $gqlQueries);
+		});
+	}
+
+
+	private function removeTimeElementFromQueryLog(array $queryLog)
+	{
+		foreach ($queryLog as &$item) {
+			unset($item['time']);
+		}
+		// unset item reference to prevent unexpected stuff
+		unset($item);
+
+		return $queryLog;
+	}
+}

--- a/tests/GraphQLRelationsTest.php
+++ b/tests/GraphQLRelationsTest.php
@@ -12,15 +12,13 @@ use StudioNet\GraphQL\Tests\Entity;
  *
  * @see TestCase
  */
-class GraphQLRelationsTest extends TestCase
-{
+class GraphQLRelationsTest extends TestCase {
 	/**
 	 * Test 1-1 Relation
 	 *
 	 * @return void
 	 */
-	public function testOneToOneRelation()
-	{
+	public function testOneToOneRelation() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->phone()->save(factory(Entity\Phone::class)->make());
 		});
@@ -56,8 +54,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testOneToOneRelationInverse()
-	{
+	public function testOneToOneRelationInverse() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->phone()->save(factory(Entity\Phone::class)->make());
 		});
@@ -94,8 +91,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testOneToManyRelation()
-	{
+	public function testOneToManyRelation() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->posts()->saveMany(factory(Entity\Post::class, 5)->make());
 		});
@@ -132,8 +128,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testOneToManyRelationInverse()
-	{
+	public function testOneToManyRelationInverse() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->posts()->saveMany(factory(Entity\Post::class, 5)->make());
 		});
@@ -170,8 +165,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testHasManyThroughRelation()
-	{
+	public function testHasManyThroughRelation() {
 		factory(Entity\Country::class, 2)->create()->each(function ($country) {
 			factory(Entity\User::class, 2)->create([
 				'country_id' => $country->id
@@ -213,8 +207,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testPolymorphicOneToOneRelation()
-	{
+	public function testPolymorphicOneToOneRelation() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->comments()->saveMany(factory(Entity\Comment::class, 5)->make());
 		});
@@ -250,8 +243,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testPolymorphicManyToManyRelation()
-	{
+	public function testPolymorphicManyToManyRelation() {
 		factory(Entity\User::class, 5)->create()->each(function ($user) {
 			$user->labels()->saveMany(factory(Entity\Label::class, 5)->make());
 		});
@@ -287,8 +279,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testPolymorphicManyToManyRelationInverse()
-	{
+	public function testPolymorphicManyToManyRelationInverse() {
 		factory(Entity\User::class, 4)->create()->each(function ($user) {
 			$user->labels()->saveMany(factory(Entity\Label::class, 3)->make());
 			factory(Entity\Post::class, 2)->create([
@@ -330,8 +321,7 @@ class GraphQLRelationsTest extends TestCase
 	 *
 	 * @return void
 	 */
-	public function testDeepRelations()
-	{
+	public function testDeepRelations() {
 		factory(Entity\Country::class, 2)->create()->each(function ($country) {
 			factory(Entity\User::class, 2)->create([
 				'country_id' => $country->id
@@ -395,8 +385,7 @@ class GraphQLRelationsTest extends TestCase
 	}
 
 
-	private function removeTimeElementFromQueryLog(array $queryLog)
-	{
+	private function removeTimeElementFromQueryLog(array $queryLog) {
 		foreach ($queryLog as &$item) {
 			unset($item['time']);
 		}

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -189,7 +189,15 @@ class GraphQLTest extends TestCase {
 		$graphql->registerDefinition(Definition\TagDefinition::class);
 
 		$this->specify('test equality filtering', function () {
-			$query = 'query ($filter: UserFilter) { users(filter: $filter) { name }}';
+			$query = <<<'EOGQL'
+query ($filter: UserFilter) {
+	users(filter: $filter) {
+		items {
+			name
+		}
+	}
+}
+EOGQL;
 			$user = Entity\User::find(1);
 
 			$this->assertGraphQLEquals(
@@ -197,8 +205,10 @@ class GraphQLTest extends TestCase {
 				[
 				'data' => [
 					'users' => [
-						[
-							'name' => $user->name
+						'items' => [
+							[
+								'name' => $user->name
+							]
 						]
 					]
 				]
@@ -227,7 +237,13 @@ class GraphQLTest extends TestCase {
 		$graphql->registerDefinition(Definition\TagDefinition::class);
 
 		$this->specify('test equality containing', function () {
-			$query = 'query ($filter: UserFilter) { users(filter: $filter) { id }}';
+			$query = <<<'EOGQL'
+query ($filter: UserFilter) {
+	users(filter: $filter) {
+		items { id }
+	}
+}
+EOGQL;
 
 			$res = $this->executeGraphQL($query, [
 				'variables' => [
@@ -239,7 +255,7 @@ class GraphQLTest extends TestCase {
 
 			$this->assertSame(
 				['1','3'],
-				array_column($res['data']['users'], 'id')
+				array_column($res['data']['users']['items'], 'id')
 			);
 		});
 	}
@@ -261,7 +277,15 @@ class GraphQLTest extends TestCase {
 
 		$this->specify('test equality custom', function () {
 			// We should only get users which name starts with 'ba'
-			$query = 'query ($filter: UserFilter) { users(filter: $filter) { name }}';
+			$query = <<<'EOGQL'
+query ($filter: UserFilter) {
+	users(filter: $filter) {
+		items {
+				name
+		}
+	}
+}
+EOGQL;
 
 			$res = $this->executeGraphQL($query, [
 				'variables' => [
@@ -273,7 +297,7 @@ class GraphQLTest extends TestCase {
 
 			$this->assertSame(
 				['bar','baz'],
-				array_column($res['data']['users'], 'name')
+				array_column($res['data']['users']['items'], 'name')
 			);
 		});
 	}

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -3,7 +3,6 @@ namespace StudioNet\GraphQL\Tests;
 
 use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
-use GraphQL\Type\Definition\Type as GraphQLType;
 use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
 use StudioNet\GraphQL\Tests\GraphQL\Query\Viewer;

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -138,19 +138,11 @@ class GraphQLTest extends TestCase {
 	public function testCamelCaseQuery() {
 		factory(Entity\User::class)->create();
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', [
+		$this->registerAllDefinitionsCamelCase([
 			'query' => [
 				Viewer::class
 			]
 		]);
-		$graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
-		$graphql->registerDefinition(Definition\PhoneDefinition::class);
-		$graphql->registerDefinition(Definition\CountryDefinition::class);
-		$graphql->registerDefinition(Definition\CommentDefinition::class);
-		$graphql->registerDefinition(Definition\LabelDefinition::class);
 
 		$this->specify('test querying a single row with camel case fields', function () {
 			$query = 'query { user(id: 1) { name, isAdmin }}';

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type as GraphQLType;
 use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
+use StudioNet\GraphQL\Tests\GraphQL\Query\Viewer;
 
 /**
  * Singleton tests
@@ -29,10 +30,9 @@ class GraphQLTest extends TestCase {
 	 * @return void
 	 */
 	public function testRegisterDefinition() {
+		$this->registerAllDefinitions();
+
 		$graphql = app(GraphQL::class);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
 
 		$this->specify('ensure that we can call registered type', function () use ($graphql) {
 			$this->assertInstanceOf(ObjectType::class, $graphql->type('user'));
@@ -52,11 +52,7 @@ class GraphQLTest extends TestCase {
 			$user->posts()->saveMany(factory(Entity\Post::class, 5)->make());
 		});
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('test querying a single row', function () {
 			$query = 'query { user(id: 1) { name, posts { title } }}';
@@ -86,11 +82,7 @@ class GraphQLTest extends TestCase {
 	public function testScalar() {
 		factory(Entity\User::class)->create();
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('tests datetime rfc3339 type', function () {
 			$query = 'query { user(id: 1) { last_login } }';
@@ -118,15 +110,11 @@ class GraphQLTest extends TestCase {
 	public function testCustomQuery() {
 		factory(Entity\User::class)->create();
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', [
+		$this->registerAllDefinitions([
 			'query' => [
-				\StudioNet\GraphQL\Tests\GraphQL\Query\Viewer::class
+				Viewer::class
 			]
 		]);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
 
 		$this->specify('tests custom query (viewer)', function () {
 			$query = 'query { viewer { id, name }}';
@@ -154,12 +142,16 @@ class GraphQLTest extends TestCase {
 		$graphql = app(GraphQL::class);
 		$graphql->registerSchema('default', [
 			'query' => [
-				\StudioNet\GraphQL\Tests\GraphQL\Query\Viewer::class
+				Viewer::class
 			]
 		]);
 		$graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
 		$graphql->registerDefinition(Definition\PostDefinition::class);
 		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$graphql->registerDefinition(Definition\PhoneDefinition::class);
+		$graphql->registerDefinition(Definition\CountryDefinition::class);
+		$graphql->registerDefinition(Definition\CommentDefinition::class);
+		$graphql->registerDefinition(Definition\LabelDefinition::class);
 
 		$this->specify('test querying a single row with camel case fields', function () {
 			$query = 'query { user(id: 1) { name, isAdmin }}';
@@ -182,11 +174,7 @@ class GraphQLTest extends TestCase {
 	public function testFiltersEquality() {
 		factory(Entity\User::class, 2)->create();
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('test equality filtering', function () {
 			$query = <<<'EOGQL'
@@ -230,11 +218,7 @@ EOGQL;
 	public function testFiltersContains() {
 		factory(Entity\User::class, 3)->create();
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('test equality containing', function () {
 			$query = <<<'EOGQL'
@@ -269,11 +253,7 @@ EOGQL;
 		factory(Entity\User::class)->create(['name' => 'baz']);
 		factory(Entity\User::class)->create(['name' => 'foobar']);
 
-		$graphql = app(GraphQL::class);
-		$graphql->registerSchema('default', []);
-		$graphql->registerDefinition(Definition\UserDefinition::class);
-		$graphql->registerDefinition(Definition\PostDefinition::class);
-		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$this->registerAllDefinitions();
 
 		$this->specify('test equality custom', function () {
 			// We should only get users which name starts with 'ba'

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -6,6 +6,7 @@ use GraphQL\Type\Definition\ObjectType;
 use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
 use StudioNet\GraphQL\Tests\GraphQL\Query\SimpleString;
+use StudioNet\GraphQL\Tests\GraphQL\Query\Unauthorized;
 use StudioNet\GraphQL\Tests\GraphQL\Query\Viewer;
 
 /**
@@ -151,6 +152,42 @@ class GraphQLTest extends TestCase {
 			$this->assertGraphQLEquals($query, [
 				'data' => [
 					'simplestring' => 'You got this!'
+				]
+			]);
+		});
+	}
+
+	/**
+	 * Test authorize checking
+	 *
+	 * @return void
+	 */
+	public function testAuthorizeChecking() {
+		factory(Entity\User::class)->create();
+
+		$this->registerAllDefinitions([
+			'query' => [
+				Unauthorized::class
+			]
+		]);
+
+		$this->specify('tests unauthorized query (Unauthorized)', function () {
+			$query = 'query { unauthorized }';
+
+			$this->assertGraphQLEquals($query, [
+				'data' => [
+					'unauthorized' => null
+				],
+				'errors' => [
+					[
+						'message' => 'UNAUTHORIZED',
+						'locations' => [
+							[
+								'line' => 1,
+								'column' => 9
+							]
+						]
+					]
 				]
 			]);
 		});

--- a/tests/GraphQLTest.php
+++ b/tests/GraphQLTest.php
@@ -5,6 +5,7 @@ use GraphQL\Type\Definition\ListOfType;
 use GraphQL\Type\Definition\ObjectType;
 use StudioNet\GraphQL\GraphQL;
 use StudioNet\GraphQL\Tests\Entity;
+use StudioNet\GraphQL\Tests\GraphQL\Query\SimpleString;
 use StudioNet\GraphQL\Tests\GraphQL\Query\Viewer;
 
 /**
@@ -125,6 +126,31 @@ class GraphQLTest extends TestCase {
 						'id' => (string) $user->id,
 						'name' => $user->name,
 					]
+				]
+			]);
+		});
+	}
+
+	/**
+	 * Test simple string query
+	 *
+	 * @return void
+	 */
+	public function testSimpleStringQuery() {
+		factory(Entity\User::class)->create();
+
+		$this->registerAllDefinitions([
+			'query' => [
+				SimpleString::class
+			]
+		]);
+
+		$this->specify('tests simple string query (SimpleString)', function () {
+			$query = 'query { simplestring }';
+
+			$this->assertGraphQLEquals($query, [
+				'data' => [
+					'simplestring' => 'You got this!'
 				]
 			]);
 		});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,7 @@ abstract class TestCase extends BaseTestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-	
+
 		// Laravel 5.4 has implemented the service provider's
 		// `loadMigrationsFrom' method and removes the --realpath migrate
 		// option. So, we need to handle unit test for either version
@@ -120,5 +120,22 @@ abstract class TestCase extends BaseTestCase {
 	 */
 	public function assertGraphQLEquals($query, array $assert, array $opts = []) {
 		$this->assertSame($assert, $this->executeGraphQL($query, $opts));
+	}
+
+	/**
+	 * Register all definitions for tests
+	 *
+	 * @param array $registerSchemaOptions Used as second parameter for $graphql->registerSchema()
+	 */
+	public function registerAllDefinitions($registerSchemaOptions = []) {
+		$graphql = app(GraphQL::class);
+		$graphql->registerSchema('default', $registerSchemaOptions);
+		$graphql->registerDefinition(Definition\UserDefinition::class);
+		$graphql->registerDefinition(Definition\PostDefinition::class);
+		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$graphql->registerDefinition(Definition\PhoneDefinition::class);
+		$graphql->registerDefinition(Definition\CountryDefinition::class);
+		$graphql->registerDefinition(Definition\CommentDefinition::class);
+		$graphql->registerDefinition(Definition\LabelDefinition::class);
 	}
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -138,4 +138,21 @@ abstract class TestCase extends BaseTestCase {
 		$graphql->registerDefinition(Definition\CommentDefinition::class);
 		$graphql->registerDefinition(Definition\LabelDefinition::class);
 	}
+
+	/**
+	 * Register all definitions for tests
+	 *
+	 * @param array $registerSchemaOptions Used as second parameter for $graphql->registerSchema()
+	 */
+	public function registerAllDefinitionsCamelCase($registerSchemaOptions = []) {
+		$graphql = app(GraphQL::class);
+		$graphql->registerSchema('default', $registerSchemaOptions);
+		$graphql->registerDefinition(Definition\CamelCaseUserDefinition::class);
+		$graphql->registerDefinition(Definition\PostDefinition::class);
+		$graphql->registerDefinition(Definition\TagDefinition::class);
+		$graphql->registerDefinition(Definition\PhoneDefinition::class);
+		$graphql->registerDefinition(Definition\CountryDefinition::class);
+		$graphql->registerDefinition(Definition\CommentDefinition::class);
+		$graphql->registerDefinition(Definition\LabelDefinition::class);
+	}
 }


### PR DESCRIPTION
Fix for #26

As you can see, I increased fields depth, if it is a ListTransformer, because one extra depth-level goes for `items {...}`. Moreover I pick fields from `items`, and pass them then to guessing relations.

`guessWithRelations()` is now recursive and takes 3 params

- Eloquent model object
- Fields for the given model, so we can check for relations
- Parents relation name, as it has to be prepended to currently found relation

What do you think? As Transformers are currently used just by the lib, it has no breaking changes.      